### PR TITLE
[WIP] [Android] Fix RenderThread SIGSEGV crash with multiple auto-sizing WebViews in ScrollView

### DIFF
--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35771.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35771.cs
@@ -19,6 +19,18 @@ public class Issue35771 : NavigationPage
 						AutomationId = "Issue35771NavigateButton",
 						Text = "Open repro page",
 						Command = new Command(async () => await Navigation.PushAsync(new Issue35771ReproPage()))
+					},
+					new Button
+					{
+						AutomationId = "Issue35771HorizontalNavigateButton",
+						Text = "Open horizontal repro page",
+						Command = new Command(async () => await Navigation.PushAsync(new Issue35771HorizontalReproPage()))
+					},
+					new Button
+					{
+						AutomationId = "Issue35771PopAsyncNavigateButton",
+						Text = "Open PopAsync repro page",
+						Command = new Command(async () => await Navigation.PushAsync(new Issue35771PopAsyncReproPage()))
 					}
 				}
 			};
@@ -37,6 +49,79 @@ public class Issue35771 : NavigationPage
 					{
 						AutomationId = "Issue35771Ready",
 						Text = "Page loaded — no crash"
+					}
+				}
+			};
+
+			for (int i = 1; i <= 6; i++)
+			{
+				stack.Children.Add(new WebView
+				{
+					Source = new HtmlWebViewSource { Html = $"<html><body><p>WebView {i}</p></body></html>" }
+				});
+			}
+
+			Content = new ScrollView { Content = stack };
+		}
+	}
+
+	// Reproduces the horizontal auto-sizing crash scenario (width == 0, height > 0):
+	// WebViews inside a HorizontalStackLayout have a fixed HeightRequest but no WidthRequest,
+	// so the first layout pass produces (w=0, h>0) on the native view.
+	class Issue35771HorizontalReproPage : ContentPage
+	{
+		public Issue35771HorizontalReproPage()
+		{
+			var stack = new HorizontalStackLayout();
+
+			for (int i = 1; i <= 6; i++)
+			{
+				stack.Children.Add(new WebView
+				{
+					HeightRequest = 200,
+					Source = new HtmlWebViewSource { Html = $"<html><body><p>WebView {i}</p></body></html>" }
+				});
+			}
+
+			Content = new ScrollView
+			{
+				Orientation = ScrollOrientation.Horizontal,
+				Content = new VerticalStackLayout
+				{
+					Children =
+					{
+						new Label
+						{
+							AutomationId = "Issue35771HorizontalReady",
+							Text = "Horizontal page loaded — no crash"
+						},
+						stack
+					}
+				}
+			};
+		}
+	}
+
+	// Reproduces the PopAsync crash scenario: popping a page while WebViews are still in
+	// the dangerous (w>0, h=0) first-layout state previously caused a RenderThread SIGSEGV.
+	class Issue35771PopAsyncReproPage : ContentPage
+	{
+		public Issue35771PopAsyncReproPage()
+		{
+			var stack = new VerticalStackLayout
+			{
+				Children =
+				{
+					new Label
+					{
+						AutomationId = "Issue35771PopAsyncReady",
+						Text = "Page loaded — tap button to pop"
+					},
+					new Button
+					{
+						AutomationId = "Issue35771PopAsyncPopButton",
+						Text = "Pop back",
+						Command = new Command(async () => await Navigation.PopAsync())
 					}
 				}
 			};

--- a/src/Controls/tests/TestCases.HostApp/Issues/Issue35771.cs
+++ b/src/Controls/tests/TestCases.HostApp/Issues/Issue35771.cs
@@ -1,0 +1,55 @@
+namespace Maui.Controls.Sample.Issues;
+
+[Issue(IssueTracker.Github, 35771, "Android SIGSEGV crash with multiple auto-sizing WebViews in ScrollView on navigated page", PlatformAffected.Android)]
+public class Issue35771 : NavigationPage
+{
+	public Issue35771() : base(new Issue35771HomePage()) { }
+
+	class Issue35771HomePage : ContentPage
+	{
+		public Issue35771HomePage()
+		{
+			Content = new VerticalStackLayout
+			{
+				VerticalOptions = LayoutOptions.Center,
+				Children =
+				{
+					new Button
+					{
+						AutomationId = "Issue35771NavigateButton",
+						Text = "Open repro page",
+						Command = new Command(async () => await Navigation.PushAsync(new Issue35771ReproPage()))
+					}
+				}
+			};
+		}
+	}
+
+	class Issue35771ReproPage : ContentPage
+	{
+		public Issue35771ReproPage()
+		{
+			var stack = new VerticalStackLayout
+			{
+				Children =
+				{
+					new Label
+					{
+						AutomationId = "Issue35771Ready",
+						Text = "Page loaded — no crash"
+					}
+				}
+			};
+
+			for (int i = 1; i <= 6; i++)
+			{
+				stack.Children.Add(new WebView
+				{
+					Source = new HtmlWebViewSource { Html = $"<html><body><p>WebView {i}</p></body></html>" }
+				});
+			}
+
+			Content = new ScrollView { Content = stack };
+		}
+	}
+}

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35771.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35771.cs
@@ -1,0 +1,24 @@
+// Crash is Android-specific: RenderThread GL functor receives zero-area Skia canvas when ClipBounds=(0,0,0,0) at (w>0,h=0)
+#if ANDROID
+using NUnit.Framework;
+using UITest.Appium;
+using UITest.Core;
+
+namespace Microsoft.Maui.TestCases.Tests.Issues;
+
+public class Issue35771 : _IssuesUITest
+{
+	public Issue35771(TestDevice device) : base(device) { }
+
+	public override string Issue => "Android SIGSEGV crash with multiple auto-sizing WebViews in ScrollView on navigated page";
+
+	[Test]
+	[Category(UITestCategories.WebView)]
+	public void MultipleAutoSizingWebViewsInScrollViewShouldNotCrash()
+	{
+		App.WaitForElement("Issue35771NavigateButton");
+		App.Tap("Issue35771NavigateButton");
+		App.WaitForElement("Issue35771Ready");
+	}
+}
+#endif

--- a/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35771.cs
+++ b/src/Controls/tests/TestCases.Shared.Tests/Tests/Issues/Issue35771.cs
@@ -19,6 +19,30 @@ public class Issue35771 : _IssuesUITest
 		App.WaitForElement("Issue35771NavigateButton");
 		App.Tap("Issue35771NavigateButton");
 		App.WaitForElement("Issue35771Ready");
+		App.Back();
+		App.WaitForElement("Issue35771NavigateButton");
+	}
+
+	[Test]
+	[Category(UITestCategories.WebView)]
+	public void HorizontalAutoSizingWebViewsShouldNotCrash()
+	{
+		App.WaitForElement("Issue35771HorizontalNavigateButton");
+		App.Tap("Issue35771HorizontalNavigateButton");
+		App.WaitForElement("Issue35771HorizontalReady");
+		App.Back();
+		App.WaitForElement("Issue35771NavigateButton");
+	}
+
+	[Test]
+	[Category(UITestCategories.WebView)]
+	public void PopAsyncFromAutoSizingWebViewPageShouldNotCrash()
+	{
+		App.WaitForElement("Issue35771PopAsyncNavigateButton");
+		App.Tap("Issue35771PopAsyncNavigateButton");
+		App.WaitForElement("Issue35771PopAsyncReady");
+		App.Tap("Issue35771PopAsyncPopButton");
+		App.WaitForElement("Issue35771NavigateButton");
 	}
 }
 #endif

--- a/src/Core/src/Platform/Android/MauiHybridWebView.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebView.cs
@@ -18,9 +18,9 @@ namespace Microsoft.Maui.Platform
 		private static readonly AUri AndroidAppOriginUri = AUri.Parse(HybridWebViewHandler.AppOrigin)!;
 		readonly Rect _clipRect;
 
-		// True after the first layout pass where one dimension is positive and the other is zero.
-		// Once set, ClipBounds stays null for this instance's lifetime — a zero-area ClipBounds
-		// in this state causes RenderThread to crash on an incomplete Skia canvas (SIGSEGV).
+		// True after the first layout pass where exactly one dimension is positive and the other is zero.
+		// Auto-sizing layouts produce this intermediate state; a zero-area ClipBounds here
+		// causes RenderThread to crash on an incomplete Skia canvas (SIGSEGV).
 		// https://github.com/dotnet/maui/issues/35771
 		bool _isAutoSizing;
 
@@ -52,10 +52,11 @@ namespace Microsoft.Maui.Platform
 
 		void UpdateClipBounds(int width, int height)
 		{
-			// Auto-sizing layouts (e.g. VerticalStackLayout with no HeightRequest) produce a first
-			// layout pass with a positive width but zero height, or vice-versa. A zero-area ClipBounds
-			// in this state causes RenderThread to crash (SIGSEGV). Null disables clipping; the latch
-			// prevents later layout passes from re-enabling it before both dimensions are stable.
+			// Auto-sizing layouts produce an intermediate layout pass where exactly one dimension
+			// is positive and the other is zero: vertical layouts give (w>0, h=0) first; horizontal
+			// layouts give (w=0, h>0) first. A zero-area ClipBounds in either state causes
+			// RenderThread to crash (SIGSEGV). Null disables clipping; the latch prevents later
+			// layout passes from re-enabling it before both dimensions are stable.
 			// https://github.com/dotnet/maui/issues/35771
 			if (_isAutoSizing || (width > 0 && height == 0) || (width == 0 && height > 0))
 			{

--- a/src/Core/src/Platform/Android/MauiHybridWebView.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebView.cs
@@ -18,11 +18,10 @@ namespace Microsoft.Maui.Platform
 		private static readonly AUri AndroidAppOriginUri = AUri.Parse(HybridWebViewHandler.AppOrigin)!;
 		readonly Rect _clipRect;
 
-		// True once this instance observes (w>0, h=0) — the layout signature of a WebView
-		// in an unconstrained-height container (e.g. ScrollView). ClipBounds is kept null
-		// for the rest of the instance lifetime to avoid SIGSEGV: any non-null value causes
-		// RenderThread to invoke the GL functor on off-screen views, which receive a zero-area
-		// Skia canvas and crash. https://github.com/dotnet/maui/issues/35771
+		// True after the first layout pass where one dimension is positive and the other is zero.
+		// Once set, ClipBounds stays null for this instance's lifetime — a zero-area ClipBounds
+		// in this state causes RenderThread to crash on an incomplete Skia canvas (SIGSEGV).
+		// https://github.com/dotnet/maui/issues/35771
 		bool _isAutoSizing;
 
 		public MauiHybridWebView(HybridWebViewHandler handler, Context context) : base(context)
@@ -53,12 +52,12 @@ namespace Microsoft.Maui.Platform
 
 		void UpdateClipBounds(int width, int height)
 		{
-			// (w>0, h=0) is the layout signature of a WebView inside an unconstrained-height
-			// container waiting for JS to measure content height. Keeping ClipBounds null
-			// prevents SIGSEGV: a non-null value causes RenderThread to invoke the GL functor
-			// on off-screen views with a zero-area Skia canvas.
+			// Auto-sizing layouts (e.g. VerticalStackLayout with no HeightRequest) produce a first
+			// layout pass with a positive width but zero height, or vice-versa. A zero-area ClipBounds
+			// in this state causes RenderThread to crash (SIGSEGV). Null disables clipping; the latch
+			// prevents later layout passes from re-enabling it before both dimensions are stable.
 			// https://github.com/dotnet/maui/issues/35771
-			if (_isAutoSizing || (width > 0 && height == 0))
+			if (_isAutoSizing || (width > 0 && height == 0) || (width == 0 && height > 0))
 			{
 				_isAutoSizing = true;
 				ClipBounds = null;
@@ -85,7 +84,7 @@ namespace Microsoft.Maui.Platform
 			}
 			else
 			{
-				// width=0: zero-width views are skipped by RenderThread, so (0,0,0,0) is safe.
+				// View has no area yet or is fully collapsed — keep a zero clip rect.
 				_clipRect.Set(0, 0, 0, 0);
 				ClipBounds = _clipRect;
 			}

--- a/src/Core/src/Platform/Android/MauiHybridWebView.cs
+++ b/src/Core/src/Platform/Android/MauiHybridWebView.cs
@@ -18,6 +18,13 @@ namespace Microsoft.Maui.Platform
 		private static readonly AUri AndroidAppOriginUri = AUri.Parse(HybridWebViewHandler.AppOrigin)!;
 		readonly Rect _clipRect;
 
+		// True once this instance observes (w>0, h=0) — the layout signature of a WebView
+		// in an unconstrained-height container (e.g. ScrollView). ClipBounds is kept null
+		// for the rest of the instance lifetime to avoid SIGSEGV: any non-null value causes
+		// RenderThread to invoke the GL functor on off-screen views, which receive a zero-area
+		// Skia canvas and crash. https://github.com/dotnet/maui/issues/35771
+		bool _isAutoSizing;
+
 		public MauiHybridWebView(HybridWebViewHandler handler, Context context) : base(context)
 		{
 			ArgumentNullException.ThrowIfNull(handler, nameof(handler));
@@ -46,6 +53,19 @@ namespace Microsoft.Maui.Platform
 
 		void UpdateClipBounds(int width, int height)
 		{
+			// (w>0, h=0) is the layout signature of a WebView inside an unconstrained-height
+			// container waiting for JS to measure content height. Keeping ClipBounds null
+			// prevents SIGSEGV: a non-null value causes RenderThread to invoke the GL functor
+			// on off-screen views with a zero-area Skia canvas.
+			// https://github.com/dotnet/maui/issues/35771
+			if (_isAutoSizing || (width > 0 && height == 0))
+			{
+				_isAutoSizing = true;
+				ClipBounds = null;
+				return;
+			}
+
+			// Normal (non-auto-sizing) WebView: apply flash prevention from issue #31475.
 			if (width > 0 && height > 0)
 			{
 				if (Parent is WrapperView)
@@ -65,7 +85,7 @@ namespace Microsoft.Maui.Platform
 			}
 			else
 			{
-				// Re-apply empty clip bounds when the view becomes zero-sized or hidden.
+				// width=0: zero-width views are skipped by RenderThread, so (0,0,0,0) is safe.
 				_clipRect.Set(0, 0, 0, 0);
 				ClipBounds = _clipRect;
 			}

--- a/src/Core/src/Platform/Android/MauiWebView.cs
+++ b/src/Core/src/Platform/Android/MauiWebView.cs
@@ -13,6 +13,13 @@ namespace Microsoft.Maui.Platform
 		readonly WebViewHandler _handler;
 		readonly Rect _clipRect;
 
+		// True once this instance observes (w>0, h=0) — the layout signature of a WebView
+		// in an unconstrained-height container (e.g. ScrollView). ClipBounds is kept null
+		// for the rest of the instance lifetime to avoid SIGSEGV: any non-null value causes
+		// RenderThread to invoke the GL functor on off-screen views, which receive a zero-area
+		// Skia canvas and crash. https://github.com/dotnet/maui/issues/35771
+		//bool _isAutoSizing;
+
 		public MauiWebView(WebViewHandler handler, Context context) : base(context)
 		{
 			_handler = handler ?? throw new ArgumentNullException(nameof(handler));
@@ -40,6 +47,19 @@ namespace Microsoft.Maui.Platform
 
 		void UpdateClipBounds(int width, int height)
 		{
+			// (w>0, h=0) is the layout signature of a WebView inside an unconstrained-height
+			// container waiting for JS to measure content height. Keeping ClipBounds null
+			// prevents SIGSEGV: a non-null value causes RenderThread to invoke the GL functor
+			// on off-screen views with a zero-area Skia canvas.
+			// https://github.com/dotnet/maui/issues/35771
+			// if (_isAutoSizing || (width > 0 && height == 0))
+			// {
+			// 	_isAutoSizing = true;
+			// 	ClipBounds = null;
+			// 	return;
+			// }
+
+			// Normal (non-auto-sizing) WebView: apply flash prevention from issue #31475.
 			if (width > 0 && height > 0)
 			{
 				if (Parent is WrapperView)
@@ -59,7 +79,7 @@ namespace Microsoft.Maui.Platform
 			}
 			else
 			{
-				// Re-apply empty clip bounds when the view becomes zero-sized or hidden.
+				// width=0: zero-width views are skipped by RenderThread, so (0,0,0,0) is safe.
 				_clipRect.Set(0, 0, 0, 0);
 				ClipBounds = _clipRect;
 			}

--- a/src/Core/src/Platform/Android/MauiWebView.cs
+++ b/src/Core/src/Platform/Android/MauiWebView.cs
@@ -13,12 +13,11 @@ namespace Microsoft.Maui.Platform
 		readonly WebViewHandler _handler;
 		readonly Rect _clipRect;
 
-		// True once this instance observes (w>0, h=0) — the layout signature of a WebView
-		// in an unconstrained-height container (e.g. ScrollView). ClipBounds is kept null
-		// for the rest of the instance lifetime to avoid SIGSEGV: any non-null value causes
-		// RenderThread to invoke the GL functor on off-screen views, which receive a zero-area
-		// Skia canvas and crash. https://github.com/dotnet/maui/issues/35771
-		//bool _isAutoSizing;
+		// True after the first layout pass where one dimension is positive and the other is zero.
+		// Once set, ClipBounds stays null for this instance's lifetime — a zero-area ClipBounds
+		// in this state causes RenderThread to crash on an incomplete Skia canvas (SIGSEGV).
+		// https://github.com/dotnet/maui/issues/35771
+		bool _isAutoSizing;
 
 		public MauiWebView(WebViewHandler handler, Context context) : base(context)
 		{
@@ -47,17 +46,17 @@ namespace Microsoft.Maui.Platform
 
 		void UpdateClipBounds(int width, int height)
 		{
-			// (w>0, h=0) is the layout signature of a WebView inside an unconstrained-height
-			// container waiting for JS to measure content height. Keeping ClipBounds null
-			// prevents SIGSEGV: a non-null value causes RenderThread to invoke the GL functor
-			// on off-screen views with a zero-area Skia canvas.
+			// Auto-sizing layouts (e.g. VerticalStackLayout with no HeightRequest) produce a first
+			// layout pass with a positive width but zero height, or vice-versa. A zero-area ClipBounds
+			// in this state causes RenderThread to crash (SIGSEGV). Null disables clipping; the latch
+			// prevents later layout passes from re-enabling it before both dimensions are stable.
 			// https://github.com/dotnet/maui/issues/35771
-			// if (_isAutoSizing || (width > 0 && height == 0))
-			// {
-			// 	_isAutoSizing = true;
-			// 	ClipBounds = null;
-			// 	return;
-			// }
+			if (_isAutoSizing || (width > 0 && height == 0) || (width == 0 && height > 0))
+			{
+				_isAutoSizing = true;
+				ClipBounds = null;
+				return;
+			}
 
 			// Normal (non-auto-sizing) WebView: apply flash prevention from issue #31475.
 			if (width > 0 && height > 0)
@@ -79,7 +78,7 @@ namespace Microsoft.Maui.Platform
 			}
 			else
 			{
-				// width=0: zero-width views are skipped by RenderThread, so (0,0,0,0) is safe.
+				// View has no area yet or is fully collapsed — keep a zero clip rect.
 				_clipRect.Set(0, 0, 0, 0);
 				ClipBounds = _clipRect;
 			}

--- a/src/Core/src/Platform/Android/MauiWebView.cs
+++ b/src/Core/src/Platform/Android/MauiWebView.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Maui.Platform
 		readonly WebViewHandler _handler;
 		readonly Rect _clipRect;
 
-		// True after the first layout pass where one dimension is positive and the other is zero.
-		// Once set, ClipBounds stays null for this instance's lifetime — a zero-area ClipBounds
-		// in this state causes RenderThread to crash on an incomplete Skia canvas (SIGSEGV).
+		// True after the first layout pass where exactly one dimension is positive and the other is zero.
+		// Auto-sizing layouts produce this intermediate state; a zero-area ClipBounds here
+		// causes RenderThread to crash on an incomplete Skia canvas (SIGSEGV).
 		// https://github.com/dotnet/maui/issues/35771
 		bool _isAutoSizing;
 
@@ -46,10 +46,11 @@ namespace Microsoft.Maui.Platform
 
 		void UpdateClipBounds(int width, int height)
 		{
-			// Auto-sizing layouts (e.g. VerticalStackLayout with no HeightRequest) produce a first
-			// layout pass with a positive width but zero height, or vice-versa. A zero-area ClipBounds
-			// in this state causes RenderThread to crash (SIGSEGV). Null disables clipping; the latch
-			// prevents later layout passes from re-enabling it before both dimensions are stable.
+			// Auto-sizing layouts produce an intermediate layout pass where exactly one dimension
+			// is positive and the other is zero: vertical layouts give (w>0, h=0) first; horizontal
+			// layouts give (w=0, h>0) first. A zero-area ClipBounds in either state causes
+			// RenderThread to crash (SIGSEGV). Null disables clipping; the latch prevents later
+			// layout passes from re-enabling it before both dimensions are stable.
 			// https://github.com/dotnet/maui/issues/35771
 			if (_isAutoSizing || (width > 0 && height == 0) || (width == 0 && height > 0))
 			{


### PR DESCRIPTION
 <!-- Please let the below note in for people that find this PR -->
   > [!NOTE]
   > Are you waiting for the changes in this PR to be merged?
   > It would be very helpful if you could [test the resulting artifacts](https://github.com/dotnet/maui/wiki/Testing-PR-Builds) from this PR and let us know in a comment if this change resolves your issue. 
  Thank you!
 
### **Root Cause**

When multiple `WebView`s are placed inside a `ScrollView` or other auto-sizing layouts with unconstrained dimensions, Android initially assigns each `WebView` a partial size during the first layout pass — either `width > 0 && height == 0` (vertical layouts) or `width == 0 && height > 0` (horizontal layouts) — before content measurement completes.

At this transient state, the flash-prevention logic introduced in PR #33207 sets `ClipBounds = (0,0,0,0)` on the native view. Android’s `RenderThread` detects the non-null `ClipBounds`, invokes the GL functor, and receives a zero-area Skia canvas. `SkSurface::getCanvas()` then returns `null`, causing a native `SIGSEGV` crash (`0x20`) inside `RenderThread`.

Because this is a native rendering crash, nothing appears in managed logs.

The same crash also occurs during `PopAsync` if the page is dismissed before layout completes. The earlier `Task.Delay(400)` workaround only bypassed the crash window incidentally.

---

### **Description of Change**

Added a per-instance `_isAutoSizing` latch in both `MauiWebView` and `MauiHybridWebView` inside `UpdateClipBounds`.

The updated logic detects both confirmed dangerous transient layout states:

* `width > 0 && height == 0` — vertically auto-sizing `WebView`
* `width == 0 && height > 0` — horizontally auto-sizing `WebView`

Once either state is detected, `_isAutoSizing` is permanently latched to `true` to survive layout oscillation where a zero dimension can temporarily reappear after valid measurement.

While latched, `ClipBounds` is explicitly set to `null`, preventing Android’s `RenderThread` from scheduling the GL functor entirely. Any non-null `ClipBounds` value — including `(0,0,0,0)` — still triggers the GL pipeline and reproduces the crash.

Normal fixed-size `WebView`s that never enter these transient states remain unaffected and continue using exact `ClipBounds` for flash prevention.

---

### **Regression Introduced By**

[PR #33207](https://github.com/dotnet/maui/pull/33207)

### Issues Fixed
Fixes #35771  
 
Tested the behaviour in the following platforms
- [x] Android
- [ ] Windows
- [ ] iOS
- [ ] Mac

**Note:** This is an Android-only crash — the SIGSEGV occurs in Android's native RenderThread (GLFunctorDrawable). The ClipBounds API and GL functor pipeline are Android-specific; iOS, Mac, and Windows use entirely different rendering stacks and are not affected.

### Screenshots
| Before Issue Fix | After Issue Fix |
|------------------|-----------------|
| <video width="350" alt="withoutfix" src="https://github.com/user-attachments/assets/9224a77b-171a-46f9-9ee9-df8cc7a5350b" /> | <video width="350" alt="withfix" src="https://github.com/user-attachments/assets/cb3c59b6-b0d9-43f4-a5ff-b1f442bd6127" /> |